### PR TITLE
Update agpl license info

### DIFF
--- a/PhaserGame/package.json
+++ b/PhaserGame/package.json
@@ -1,6 +1,7 @@
 {
   "name": "card-memory",
   "version": "0.0.0",
+  "license": "AGPL-3.0-only",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # JOhn-Software
+
+## License
+
+This project is licensed under the GNU Affero General Public License v3.0 (AGPL-3.0). See `LICENSE` for full terms.
+
+Notes:
+- Modified versions offered over a network must provide the source code.
+- Third-party dependencies (Phaser and Vite) are MIT-licensed; this project’s code is AGPL-3.0-only.


### PR DESCRIPTION
Updates the project’s license information to AGPL-3.0-only according to: 
[https://spdx.org/licenses/](https://spdx.org/licenses/)

- Set the `license` field in `package.json` to `AGPL-3.0-only`  
- Added a License section in `README.md`

Closes #19