### PR TITLE
Feature/card functionality - #54

### DIFF
--- a/PhaserGame/src/config/GameConstants.ts
+++ b/PhaserGame/src/config/GameConstants.ts
@@ -224,13 +224,13 @@ export const DIFFICULTY_CONFIG: Record<DifficultyMode, DifficultyConfig> = {
   medium: {
     operators: ['+', '-', '*', '/'],
     minNumber: 1,
-    maxNumber: 20,
+    maxNumber: 9,
     maxLevels: 7
   },
   hard: {
     operators: ['+', '-', '*', '/', '^'],
     minNumber: 1,
-    maxNumber: 50,
+    maxNumber: 9,
     maxLevels: 10
   }
 };

--- a/PhaserGame/src/utils/ExpressionEvaluator.ts
+++ b/PhaserGame/src/utils/ExpressionEvaluator.ts
@@ -1,15 +1,31 @@
 import { Parser } from "expr-eval";
 
 export function evaluateExpression(cards: string[]): number {
-  const sanitized = cards
-    .filter(c => c !== "?")
-    .map(c => (c === "x" ? "*" : c === "÷" ? "/" : c));
-
-  const expr = sanitized.join(" ").trim();
+  // Concatenate adjacent numbers, evaluate normally when operators are present
+  if (!cards || cards.length === 0) return NaN;
+  const processed: string[] = [];
+  let i = 0;
+  while (i < cards.length) {
+    if (/^\d+$/.test(cards[i])) {
+      let numStr = cards[i];
+      // Concatenate all subsequent adjacent numbers
+      while (i + 1 < cards.length && /^\d+$/.test(cards[i + 1])) {
+        numStr += cards[i + 1];
+        i++;
+      }
+      processed.push(numStr);
+    } else if (cards[i] === "x") {
+      processed.push("*");
+    } else if (cards[i] === "÷") {
+      processed.push("/");
+    } else if (cards[i] !== "?") {
+      processed.push(cards[i]);
+    }
+    i++;
+  }
+  const expr = processed.join(" ").trim();
   if (!expr) return NaN;
-
   try {
-    // Parser validates + evaluates without using eval/new Function
     const parser = new Parser({ operators: { add: true, subtract: true, multiply: true, divide: true, power: true }});
     const value = parser.evaluate(expr);
     if (typeof value !== "number" || !isFinite(value)) return NaN;

--- a/PhaserGame/src/utils/ExpressionEvaluator.ts
+++ b/PhaserGame/src/utils/ExpressionEvaluator.ts
@@ -8,12 +8,26 @@ export function evaluateExpression(cards: string[]): number {
   while (i < cards.length) {
     if (/^\d+$/.test(cards[i])) {
       let numStr = cards[i];
-      // Concatenate all subsequent adjacent numbers
-      while (i + 1 < cards.length && /^\d+$/.test(cards[i + 1])) {
-        numStr += cards[i + 1];
-        i++;
+      // Concatenate subsequent numbers, skipping over any '?' placeholders between digits
+      let j = i + 1;
+      let lastDigitIndex = i;
+      while (j < cards.length) {
+        const token = cards[j];
+        if (token === "?") {
+          j++;
+          continue; // ignore placeholders between digits
+        }
+        if (/^\d+$/.test(token)) {
+          numStr += token;
+          lastDigitIndex = j;
+          j++;
+          continue;
+        }
+        break; // stop when encountering a non-digit, non-placeholder token
       }
       processed.push(numStr);
+      // Advance i to the last digit we consumed (could have skipped over '?'s)
+      i = lastDigitIndex;
     } else if (cards[i] === "x") {
       processed.push("*");
     } else if (cards[i] === "÷") {

--- a/PhaserGame/tests/ExpressionUtils.test.ts
+++ b/PhaserGame/tests/ExpressionUtils.test.ts
@@ -55,8 +55,29 @@ describe('ExpressionEvaluator', () => {
         });
 
         it('should handle single number', () => {
-            const result = evaluateExpression(['42']);
-            expect(result).toBe(42);
+            const result = evaluateExpression(['4']);
+            expect(result).toBe(4);
+        });
+
+
+        it("should concatenate digits separated by placeholder into a single number", () => {
+            const result = evaluateExpression(["1", "?", "2"]);
+            expect(result).toBe(12);
+        });
+
+        it("should concatenate multiple digits with multiple placeholders", () => {
+            const result = evaluateExpression(["1", "?", "?", "2", "?", "3"]);
+            expect(result).toBe(123);
+        });
+
+        it("should ignore placeholders between numbers around operators", () => {
+            const result = evaluateExpression(["1", "?", "2", "+", "3", "?"]);
+            expect(result).toBe(15);
+        });
+
+        it("should ignore placeholders between numbers around operators", () => {
+            const result = evaluateExpression(["?", "2", "?","+", "?","3"]);
+            expect(result).toBe(5);
         });
 
         it('should evaluate expressions with negative results', () => {


### PR DESCRIPTION
## Summary
Added card concatenation to create a more realistic game scenario where cards can form multiple-digit numbers.

Closes: #54
Note: This issue was initially worked on by @nadiaaskari  but was transferred to @manan501  due to the workload being split between 2 members. All of the initial work was incorporated.

## Why
Cards were only single-digit before.

## What’s included
- Changes to the expression evaluator to read cards in a line and concatenate them
- Change to solvable hand generator to concatenate cards and create objectives based on those

## Test coverage added
Scenarios:
1. Concatenate cards next to each other
2. Concatenate cards with a space in between them
3. Concatenate cars with a space in between the operators

## Verification and testing this PR
Run npm install and then npm run dev on the PhaserGame directory
Test cases pass for card concatenation